### PR TITLE
Temporary fix for the geometry feed in spotlights

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -657,7 +657,7 @@ GFXVertexBufferHandle<AdvancedLightManager::LightVertex> AdvancedLightManager::g
       for (S32 i=1; i<numPoints + 1; i++)
       {
          S32 imod = (i - 1) % numPoints;
-         mConeGeometry[i].point = Point3F(circlePoints[imod].x,circlePoints[imod].y, -1.0f);
+         mConeGeometry[i].point = Point3F(circlePoints[imod].x*1.1,circlePoints[imod].y*1.1, -1.0f);
          mConeGeometry[i].color = ColorI::WHITE;
       }
       mConeGeometry.unlock();
@@ -705,7 +705,7 @@ LightShadowMap* AdvancedLightManager::findShadowMapForObject( SimObject *object 
    return sceneLight->getLight()->getExtended<ShadowMapParams>()->getShadowMap();
 }
 
-DefineEngineFunction( setShadowVizLight, const char*, (const char* name), (""), "")
+DefineConsoleFunction( setShadowVizLight, const char*, (const char* name), (""), "")
 {
    static const String DebugTargetName( "AL_ShadowVizTexture" );
 
@@ -734,4 +734,3 @@ DefineEngineFunction( setShadowVizLight, const char*, (const char* name), (""), 
    dSprintf( result, bufSize, "%d %d %g", size.x, size.y, aspect ); 
    return result;
 }
-


### PR DESCRIPTION
Done by Azaezel
Spotlights were breaking depending of the angle and distance after a certain radius.

Preview:
![Sp1](https://user-images.githubusercontent.com/49202102/55427082-a24fc600-555c-11e9-9d1c-3ca8b6b9caac.jpg)
![sp2](https://user-images.githubusercontent.com/49202102/55427090-a4198980-555c-11e9-9349-c013013e92ae.jpg)
