### PR TITLE
Temporary fix for the geometry feed in spotlights

### DIFF
--- a/Engine/source/lighting/advanced/advancedLightManager.cpp
+++ b/Engine/source/lighting/advanced/advancedLightManager.cpp
@@ -657,7 +657,7 @@ GFXVertexBufferHandle<AdvancedLightManager::LightVertex> AdvancedLightManager::g
       for (S32 i=1; i<numPoints + 1; i++)
       {
          S32 imod = (i - 1) % numPoints;
-         mConeGeometry[i].point = Point3F(circlePoints[imod].x,circlePoints[imod].y, -1.0f);
+         mConeGeometry[i].point = Point3F(circlePoints[imod].x*1.1,circlePoints[imod].y*1.1, -1.0f);
          mConeGeometry[i].color = ColorI::WHITE;
       }
       mConeGeometry.unlock();
@@ -705,7 +705,7 @@ LightShadowMap* AdvancedLightManager::findShadowMapForObject( SimObject *object 
    return sceneLight->getLight()->getExtended<ShadowMapParams>()->getShadowMap();
 }
 
-DefineEngineFunction( setShadowVizLight, const char*, (const char* name), (""), "")
+DefineConsoleFunction( setShadowVizLight, const char*, (const char* name), (""), "")
 {
    static const String DebugTargetName( "AL_ShadowVizTexture" );
 


### PR DESCRIPTION
Done by Azaezel
Spotlights were breaking depending of the angle and distance after a certain radius.

Preview:
![Sp1](https://user-images.githubusercontent.com/49209270/55428857-6d457280-5560-11e9-8c7a-479f26306f8f.jpg)
![sp2](https://user-images.githubusercontent.com/49209270/55428858-6fa7cc80-5560-11e9-9847-164776b677a3.jpg)
